### PR TITLE
FIX: Fatal error when JetSmartFilters is not active

### DIFF
--- a/includes/integration.php
+++ b/includes/integration.php
@@ -263,10 +263,12 @@ class Integration {
 			$query = $this->get_default_query( $this->query );
 		}
 
-		if ( isset( $_REQUEST['action'] ) && 'jet_smart_filters' === $_REQUEST['action'] ) {
-			$query = jet_smart_filters()->query->get_query_args();
-		} elseif ( ! empty( jet_smart_filters()->query->get_query_args() ) ) {
-			$query = $this->get_default_query( $this->query );
+		if( function_exists( 'jet_smart_filters' ) ){
+			if ( isset( $_REQUEST['action'] ) && 'jet_smart_filters' === $_REQUEST['action'] ) {
+				$query = jet_smart_filters()->query->get_query_args();
+			} elseif ( ! empty( jet_smart_filters()->query->get_query_args() ) ) {
+				$query = $this->get_default_query( $this->query );
+			}
 		}
 
 		if ( isset( $_REQUEST['action'] ) && 'jet_woo_builder_load_more' === $_REQUEST['action'] ) {


### PR DESCRIPTION
Fix error `PHP Fatal error: Uncaught Error: Call to undefined function JWB_PGLM\jet_smart_filters() in /www/wp-content/plugins/jwb-products-grid-load-more-main/includes/integration.php:268`